### PR TITLE
feat: support Llama3.1 and Yarn RoPE

### DIFF
--- a/llm_torch/architectures/__init__.py
+++ b/llm_torch/architectures/__init__.py
@@ -1,7 +1,7 @@
 from llm_torch.architectures.gpt import GPT2
-from llm_torch.architectures.llama import Llama2, Llama3
+from llm_torch.architectures.llama import Llama2, Llama3, Llama31
 
-__all__ = ["GPT2", "Llama2", "Llama3", "get"]
+__all__ = ["GPT2", "Llama2", "Llama3", "Llama31", "get"]
 
 
 def get(name: str):
@@ -12,5 +12,7 @@ def get(name: str):
         return Llama2
     elif name.lower() == "llama3":
         return Llama3
+    elif name.lower() == "llama31":
+        return Llama31
     else:
         raise ValueError(f"Unknown LLM architecture: {name}.")

--- a/llm_torch/configs/__init__.py
+++ b/llm_torch/configs/__init__.py
@@ -1,10 +1,11 @@
-from llm_torch.configs.configs import LLMConfig, TrainerConfig, DatasetConfig, CallbackConfig, ModelConfig
+from llm_torch.configs.configs import (LLMConfig, TrainerConfig, DatasetConfig,
+                                       CallbackConfig, ModelConfig, YarnConfig)
 from llm_torch.configs.gpt import GPT2_CONFIG_124
-from llm_torch.configs.llama import LLAMA2_CONFIG_7B, LLAMA3_CONFIG_8B
+from llm_torch.configs.llama import LLAMA2_CONFIG_7B, LLAMA3_CONFIG_8B, LLAMA31_CONFIG_8B
 
 
-__all__ = ["get", "LLMConfig", "GPT2_CONFIG_124", "LLAMA2_CONFIG_7B", "LLAMA3_CONFIG_8B",
-           "TrainerConfig", "DatasetConfig", "CallbackConfig", "ModelConfig"]
+__all__ = ["get", "LLMConfig", "GPT2_CONFIG_124", "LLAMA2_CONFIG_7B", "LLAMA3_CONFIG_8B", "LLAMA31_CONFIG_8B",
+           "TrainerConfig", "DatasetConfig", "CallbackConfig", "ModelConfig", "YarnConfig"]
 
 
 def get(name, size):

--- a/llm_torch/configs/configs.py
+++ b/llm_torch/configs/configs.py
@@ -16,6 +16,20 @@ class DatasetConfig:
 
 
 @dataclass
+class RoPEConfig:
+    theta_base: float = 10_000
+
+
+@dataclass
+class YarnConfig:
+    factor: float
+    low_freq: float
+    high_freq: float
+    original_max_pos_embeddings: Optional[int] = None
+    theta_base: float = 10_000
+
+
+@dataclass
 class ModelConfig:
     emb_dim: int
     n_heads: int
@@ -26,6 +40,7 @@ class ModelConfig:
     kv_window_size: Optional[int] = None
     n_kv_group: Optional[int] = None
     dtype: torch.dtype = torch.float32
+    rope_scaling: Optional[RoPEConfig | YarnConfig] = None
 
     def __post_init__(self):
         if self.n_kv_group is None:

--- a/llm_torch/configs/llama.py
+++ b/llm_torch/configs/llama.py
@@ -2,7 +2,7 @@ import torch
 
 from llm_torch import configs
 from llm_torch.components import callbacks
-
+from llm_torch.configs.configs import RoPEConfig
 
 LLAMA2_CONFIG_7B = configs.LLMConfig(
     vocab_size=50257,  # 32000,
@@ -62,6 +62,54 @@ LLAMA3_CONFIG_8B = configs.LLMConfig(
        qkv_bias=False,
        dtype=torch.bfloat16,
        kv_window_size=None,
+       rope_scaling=RoPEConfig(theta_base=500_000.0)
+    ),
+    train_config=configs.TrainerConfig(
+       epochs=3,
+       eval_freq=5,
+       eval_iter=5,
+       max_grad_norm=1.0,
+       optimizer=configs.configs.OptimizerConfig(class_name=torch.optim.AdamW)
+    ),
+    callback_configs = [
+       configs.CallbackConfig(
+           class_name=callbacks.LRCosineAnnealing,
+           config=dict(peak_lr=2.5e-4, min_lr=0, initial_lr=0, warmup_steps=2000)
+       ),
+       configs.CallbackConfig(
+           class_name=callbacks.ModelCheckpoint,
+           config=dict(save_best_only=True),
+       )
+    ]
+)
+
+
+LLAMA31_CONFIG_8B = configs.LLMConfig(
+    vocab_size=50257,  # 128_256,
+    context_length=256,  # 131_072
+    dataset_config=configs.DatasetConfig(
+       batch_size=32,  # it originally trained on 512
+       shuffle=True,
+       max_length=256,
+       stride=1,
+    ),
+    model_config=configs.ModelConfig(
+       emb_dim=1024, #4096,
+       hidden_dim=2816,  #14_336
+       n_heads=16, #32,
+       n_kv_group=4, #8
+       n_layers=12, #32,
+       drop_rate=None,
+       qkv_bias=False,
+       dtype=torch.bfloat16,
+       kv_window_size=None,
+       rope_scaling=configs.YarnConfig(
+           theta_base=500_000.0,
+           factor=8.0,
+           low_freq=1.0,
+           high_freq=4.0,
+           original_max_pos_embeddings=None #8192,  # originally llama3.1 fine-tuned and not trained from scratch.
+       )
     ),
     train_config=configs.TrainerConfig(
        epochs=3,


### PR DESCRIPTION
Support LLama3.1 architecture:

- Extend RoPE with Yarn implementation, in addition add YarnConfig in configs.
- Extract Llama base architecture and just change the attention class.
- Add LLama3.1 configs.