### PR TITLE
GPT-OSS size 20B

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ This framework currently includes the following model architectures:
 
 *   **Llama3.2**: It shrunk in size comparing to Llama3.1, increased the rescaling factor of Yarn, and they added back the weight tying between the input token embedding and the output layer.
 
-*  **Qwen3**: Similar to Llama3.*, it uses `YarnGOA`, but instead of `SwiGLUBlock` it uses Mixture-of-expert `MoEBlock` for the feedforward block, where a router will choose handful of experts for every token. In addition, it adds `RMSNorm` on Key and Query of GOA. Finally, Although it uses bfloat16 as data type. However, the mean and std of `RMSNorm` is computed with float32.
+*   **GPT-OSS**: It pairs `NTKSWA` (NTK-scaled sliding-window attention) with freely configurable head dimensions and a Mixture-of-Experts feed-forward stack that routes tokens through *bounded* `SwiGLU` experts, following the 20B reference design.
+
+*   **Qwen3**: Similar to Llama3.*, it uses `YarnGOA`, but instead of `SwiGLUBlock` it uses Mixture-of-expert `MoEBlock` for the feedforward block, where a router will choose handful of experts for every token. In addition, it adds `RMSNorm` on Key and Query of GOA. Finally, Although it uses bfloat16 as data type. However, the mean and std of `RMSNorm` is computed with float32.
 
 ## Project Structure
 

--- a/llm_torch/components/__init__.py
+++ b/llm_torch/components/__init__.py
@@ -7,6 +7,8 @@ from llm_torch.components.normalizer import LayerNorm
 __all__ = [
     "GELU",
     "MultiHeadAttention",
+    "SlidingWindowAttention",
+    "GroupedKeyAttention",
     "Callback",
     "LRCosineAnnealing",
     "GenerateSample",

--- a/llm_torch/components/__init__.py
+++ b/llm_torch/components/__init__.py
@@ -1,5 +1,5 @@
 from llm_torch.components.activations import GELU
-from llm_torch.components.attention import MultiHeadAttention
+from llm_torch.components.attention import (MultiHeadAttention, SlidingWindowAttention, GroupedKeyAttention)
 from llm_torch.components.callbacks import Callback, LRCosineAnnealing, GenerateSample, ModelCheckpoint
 from llm_torch.components.feedforward_blocks import FFBlock, SwiGLUBlock
 from llm_torch.components.normalizer import LayerNorm

--- a/llm_torch/configs/__init__.py
+++ b/llm_torch/configs/__init__.py
@@ -1,7 +1,8 @@
 from llm_torch.configs.configs import (LLMConfig, TrainerConfig, DatasetConfig, CallbackConfig, ModelConfig)
 from llm_torch.configs.attention import (MultiHeadAttentionConfig, RoPEMultiHeadAttentionConfig,
                                          YarnGroupedAttentionConfig, RoPEGroupedAttentionConfig,
-                                         YarnSWAConfig, SlidingWindowAttentionConfig, NaiveSWAConfig)
+                                         YarnSWAConfig, SlidingWindowAttentionConfig, NaiveSWAConfig,
+                                         NTKSWAConfig, NTKNaiveSWAConfig)
 from llm_torch.configs.normalizer import RMSNormConfig, LayerNormConfig
 from llm_torch.configs.feedforward_blocks import SwiGLUBlockConfig, MoEConfig, FFBlockConfig
 from llm_torch.configs.activations import GELUConfig, SiLUConfig
@@ -25,6 +26,8 @@ __all__ = [
     "YarnSWAConfig",
     "SlidingWindowAttentionConfig",
     "NaiveSWAConfig",
+    "NTKNaiveSWAConfig",
+    "NTKSWAConfig",
     "GELUConfig",
     "SiLUConfig",
 ]

--- a/llm_torch/configs/__init__.py
+++ b/llm_torch/configs/__init__.py
@@ -1,6 +1,7 @@
 from llm_torch.configs.configs import (LLMConfig, TrainerConfig, DatasetConfig, CallbackConfig, ModelConfig)
 from llm_torch.configs.attention import (MultiHeadAttentionConfig, RoPEMultiHeadAttentionConfig,
-                                         YarnGroupedAttentionConfig, RoPEGroupedAttentionConfig)
+                                         YarnGroupedAttentionConfig, RoPEGroupedAttentionConfig,
+                                         YarnSWAConfig, SlidingWindowAttentionConfig, NaiveSWAConfig)
 from llm_torch.configs.normalizer import RMSNormConfig, LayerNormConfig
 from llm_torch.configs.feedforward_blocks import SwiGLUBlockConfig, MoEConfig, FFBlockConfig
 from llm_torch.configs.activations import GELUConfig, SiLUConfig
@@ -21,6 +22,9 @@ __all__ = [
     "MultiHeadAttentionConfig",
     "YarnGroupedAttentionConfig",
     "RoPEGroupedAttentionConfig",
+    "YarnSWAConfig",
+    "SlidingWindowAttentionConfig",
+    "NaiveSWAConfig",
     "GELUConfig",
     "SiLUConfig",
 ]

--- a/llm_torch/configs/attention.py
+++ b/llm_torch/configs/attention.py
@@ -9,6 +9,7 @@ from llm_torch.configs.normalizer import NormalizerConfig
 @dataclass(kw_only=True)
 class AttentionConfig(metaclass=ABCMeta):
     n_heads: int
+    head_dim: Optional[int] = None,
     dropout_rate: Optional[float] = 0.1
     qkv_bias: bool = False
     qk_norm: Optional[NormalizerConfig] = None

--- a/llm_torch/configs/feedforward_blocks.py
+++ b/llm_torch/configs/feedforward_blocks.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 from dataclasses import dataclass, fields, field
 from abc import abstractmethod, ABCMeta
-from typing import Type, Optional
+from typing import Optional
 
 from llm_torch.components import feedforward_blocks as ff_blocks
 from llm_torch.configs.activations import SiLUConfig, GELUConfig, ActivationConfig
@@ -44,7 +46,7 @@ class SwiGLUBlockConfig(FFBaseConfig):
 class MoEConfig(FFBaseConfig):
     n_experts: int
     n_experts_per_token: int = 1
-    ff_block: Type[ff_blocks.FFBaseBlock] = ff_blocks.SwiGLUBlock
+    ff_block: Optional[FFBaseConfig] = None
     activation: ActivationConfig = field(default_factory=SiLUConfig)
 
     @property

--- a/llm_torch/configs/feedforward_blocks.py
+++ b/llm_torch/configs/feedforward_blocks.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass, fields, field
 from abc import abstractmethod, ABCMeta
-from typing import Type
+from typing import Type, Optional
 
 from llm_torch.components import feedforward_blocks as ff_blocks
 from llm_torch.configs.activations import SiLUConfig, GELUConfig, ActivationConfig
@@ -33,6 +33,7 @@ class FFBlockConfig(FFBaseConfig):
 @dataclass
 class SwiGLUBlockConfig(FFBaseConfig):
     activation: ActivationConfig = field(default_factory=SiLUConfig)
+    limit: Optional[float] = None
 
     @property
     def block_class(self):

--- a/scripts/configs/__init__.py
+++ b/scripts/configs/__init__.py
@@ -1,4 +1,4 @@
-from scripts.configs.gpt import GPT2_CONFIG_124M
+from scripts.configs.gpt import GPT2_CONFIG_124M, GPT_OSS_CONFIG_20B
 from scripts.configs.llama import (LLAMA2_CONFIG_7B, LLAMA3_CONFIG_8B, LLAMA31_CONFIG_8B,
                                    LLAMA32_CONFIG_3B)
 from scripts.configs.qwen import QWEN3_CONFIG_30B
@@ -7,6 +7,7 @@ from scripts.configs.qwen import QWEN3_CONFIG_30B
 __all__ = [
     "get",
     "GPT2_CONFIG_124M",
+    "GPT_OSS_CONFIG_20B",
     "LLAMA2_CONFIG_7B",
     "LLAMA3_CONFIG_8B",
     "LLAMA31_CONFIG_8B",

--- a/scripts/configs/gpt.py
+++ b/scripts/configs/gpt.py
@@ -42,3 +42,59 @@ GPT2_CONFIG_124M = configs.LLMConfig(
         )
     ]
 )
+
+
+GPT_OSS_CONFIG_20B = configs.LLMConfig(
+    vocab_size=50257,  # 201088
+    context_length=256,
+    dataset_config=configs.DatasetConfig(
+        batch_size=32,  # it originally trained on 512
+        shuffle=True,
+        max_length=256,
+        stride=1,
+    ),
+    model_config=configs.ModelConfig(
+        emb_dim=2880,
+        dtype=torch.bfloat16,
+        n_layers=36,
+        ff_block_config=configs.MoEConfig(
+            hidden_dim=2880,
+            n_experts=128,
+            n_experts_per_token=4,
+            ff_block=configs.SwiGLUBlockConfig(
+                hidden_dim=2880,
+                activation=configs.SiLUConfig(alpha=1.702),
+                limit=7.0
+            ),
+        ),
+        normalizer_config=configs.LayerNormConfig(),
+        attention_config=configs.YarnSWAConfig(
+            n_heads=64,
+            head_dim=64,
+            n_kv_group=8,
+            window_size=128,
+            factor=32,
+            low_freq=1.0,
+            high_freq=32.0,
+            theta_base=150000.0,
+            original_max_pos_embeddings=4096
+        ),
+    ),
+    train_config=configs.TrainerConfig(
+        epochs=3,
+        eval_freq=5,
+        eval_iter=5,
+        max_grad_norm=1.0,
+        optimizer=configs.configs.OptimizerConfig(class_name=torch.optim.AdamW)
+    ),
+    callback_configs=[
+        configs.CallbackConfig(
+            class_name=callbacks.LRCosineAnnealing,
+            config=dict(peak_lr=2.5e-4, min_lr=0, initial_lr=0, warmup_steps=2000)
+        ),
+        configs.CallbackConfig(
+            class_name=callbacks.ModelCheckpoint,
+            config=dict(save_best_only=True),
+        )
+    ]
+)

--- a/scripts/configs/llama.py
+++ b/scripts/configs/llama.py
@@ -3,7 +3,6 @@ import torch
 from llm_torch import configs
 from llm_torch.components import callbacks
 
-
 LLAMA2_CONFIG_7B = configs.LLMConfig(
     vocab_size=50257,  # 32000,
     context_length=256,


### PR DESCRIPTION
## Summary

  - Extended the attention stack with GPT-OSS features: configurable head_dim, YaRN/NTK rotary mixins, and both naive
    and vectorized sliding-window attention variants to support cache-friendly long-context inference.
  - Updated feed-forward components/configs so Mixture-of-Experts layers can instantiate SwiGLU experts from config and
    optionally clamp activations, matching the GPT-OSS reference behavior.
  - Added GPT_OSS_CONFIG_20B plus the associated attention/feed-forward configs, and documented GPT-OSS alongside the
    existing model zoo in README.md.